### PR TITLE
fix unverified context example

### DIFF
--- a/data/osa-7/4-datan-kasittely.md
+++ b/data/osa-7/4-datan-kasittely.md
@@ -238,8 +238,11 @@ import json
 import ssl # lisää tämä kirjasto importeihin
 
 def hae_kaikki():
+    osoite = "https://studies.cs.helsinki.fi/stats-mock/api/courses"
     # ja tämä rivi funktioiden alkuun
     context = ssl._create_unverified_context()
+    # käytetään turvatonta kontekstia myöhemmin kutsussa
+    pyynto = urllib.request.urlopen(osoite, context=context)
     # muu koodi
 ```
 


### PR DESCRIPTION
a crucial step was missing from the example workaround  
if we wanted this change to apply to all requests process-wide, the correct line would be  
```py
ssl._create_default_https_context = ssl._create_unverified_context
```